### PR TITLE
render: Fix passing the wrong param to ...

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1152,7 +1152,12 @@ static void render_floating_container(struct sway_output *soutput,
 			render_top_border(soutput, damage, con, colors);
 		}
 		render_view(soutput, damage, con, colors);
-		render_border_textures_for_container(con, damage);
+
+		struct output_and_damage data = {
+					.output = soutput,
+					.damage = damage,
+				};
+		render_border_textures_for_container(con, &data);
 	} else {
 		render_container(soutput, damage, con, con->current.focused);
 	}


### PR DESCRIPTION
render_border_textures_for_container.

* This was causing an UB because we were trying to get an output from
  some random offset in the damage, and we were getting the damage after
  this offset, reading garbage data after the end of the damage struct
  size
* On my machine, the output offset was an nullptr, so when it got
  dereferenced, core was dumped.