### PR TITLE
Add border texture classes

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -260,6 +260,8 @@ void container_floating_move_to_center(struct sway_container *con);
 
 bool container_has_urgent_child(struct sway_container *container);
 
+bool container_has_focused_child(struct sway_container *container);
+
 /**
  * If the container is involved in a drag or resize operation via a mouse, this
  * ends the operation.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -965,6 +965,14 @@ bool container_has_urgent_child(struct sway_container *container) {
 	return container_find_child(container, find_urgent_iterator, NULL);
 }
 
+static bool find_focused_iterator(struct sway_container *con, void *data) {
+	return con->current.focused;
+}
+
+bool container_has_focused_child(struct sway_container *container) {
+	return container_find_child(container, find_focused_iterator, NULL);
+}
+
 void container_end_mouse_operation(struct sway_container *container) {
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {


### PR DESCRIPTION
This isn't the cleanest implementation because containers already get looped through to set their title, mark, and border colors beforehand. This will be fixed in a follow up PR which may also get rid of the `render_border_textures_for_workspace` method.

Fixes #6 

**Edit**: Please test it out!